### PR TITLE
Platform agnostic indent (#2)

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -5,7 +5,7 @@ export BUILDPACK_TEST_RUNNER_HOME=$(cd $(dirname $0); cd ..; pwd)
 indent() {
   c='s/^/  /'
   case $(uname) in
-    Darwin) sed -l "$c";;
+    Darwin) sed    "$c";;
     *)      sed -u "$c";;
   esac
 }


### PR DESCRIPTION
`-u` option in `sed` isn't valid on OSX systems. Originally done in pull request #3, but I'm issuing a new one because the `-l` option isn't needed either.

(Indent function ported from existing buildpacks)
