### PR TITLE
Add -C flag that enables caching, but flushes the cache beforehand.

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -18,6 +18,10 @@ indent()
   done
 }
 
+add_magic_curl_to_path() {
+  export PATH=${BUILDPACK_TEST_RUNNER_HOME}/lib/magic_curl/bin:${PATH}
+}
+
 if [ 0 -eq $# ]; then
   cat <<EOF
 Buildpack Test Runner
@@ -25,6 +29,7 @@ Buildpack Test Runner
 Usage: run [-c] [-s single_suite_test.sh] buildpack_1 [buildpack_2 [...]]
 
          -c   enable cUrl caching
+         -C   enable cUrl caching, but clear the existing cache first
          -s   specify a single test suite to run in each buildpack's test directory
 buildpack_n   local directory or a remote Git repository ending in .git for buildpack
 EOF
@@ -33,7 +38,13 @@ fi
 
 if [ "${1}" = "-c" ]; then
   shift
-  export PATH=${BUILDPACK_TEST_RUNNER_HOME}/lib/magic_curl/bin:${PATH}
+  add_magic_curl_to_path
+fi
+
+if [ "${1}" = "-C" ]; then
+  shift
+  add_magic_curl_to_path
+  cache-clear
 fi
 
 if [ "${1}" = "-s" ]; then


### PR DESCRIPTION
@ryanbrainard This is pretty handy for me. As an alternative to the `bin/run -c` flag, I added a `-C` flag that flushes the cache first. I'll leave it up to you if you want to pull it in.
