### PR TITLE
Handle case where curl is not on the system

### DIFF
--- a/lib/magic_curl/bin/curl
+++ b/lib/magic_curl/bin/curl
@@ -3,6 +3,7 @@
 #cache_dir=$(cat $(dirname ${0})/../conf/cache.conf | sed -r "s/cache_dir=(.*)$/\1/")
 cache_dir=$(sed '/^\#/d' $(dirname ${0})/../conf/cache.conf | grep 'cache_dir'  | tail -n 1 | cut -d "=" -f2-)
 
+# find the real curl cmd
 for c in $(which -a curl); do
   if [ "${c}" != "${0}" ]; then
     real_curl=${c}

--- a/lib/magic_curl/bin/curl
+++ b/lib/magic_curl/bin/curl
@@ -17,7 +17,6 @@ if [ -z "$real_curl" ]; then
   exit 1
 fi
 
-
 # find the URL argument and set path vars
 for arg; do
   # don't cache head requests

--- a/lib/magic_curl/bin/curl
+++ b/lib/magic_curl/bin/curl
@@ -3,13 +3,19 @@
 #cache_dir=$(cat $(dirname ${0})/../conf/cache.conf | sed -r "s/cache_dir=(.*)$/\1/")
 cache_dir=$(sed '/^\#/d' $(dirname ${0})/../conf/cache.conf | grep 'cache_dir'  | tail -n 1 | cut -d "=" -f2-)
 
-# find the real curl cmd
 for c in $(which -a curl); do
-  if [ ${c} != ${0} ]; then
+  if [ "${c}" != "${0}" ]; then
     real_curl=${c}
     break
   fi
 done
+
+if [ -z "$real_curl" ]; then
+  echo "curl is not on this system"
+  echo "curl is not on this system" >&2
+  exit 1
+fi
+
 
 # find the URL argument and set path vars
 for arg; do

--- a/lib/magic_curl/bin/curl
+++ b/lib/magic_curl/bin/curl
@@ -12,8 +12,7 @@ for c in $(which -a curl); do
 done
 
 if [ -z "$real_curl" ]; then
-  echo "curl is not on this system"
-  echo "curl is not on this system" >&2
+  echo "curl is not on this system" | tee /dev/stderr 
   exit 1
 fi
 


### PR DESCRIPTION
The logic for this original check:

```
${c} != ${0}
```

Returns true even if the values are the same. In the case where curl is not present on the system (other than via magic curl) we cannot continue and must exit, preferably loudly.